### PR TITLE
Use /root as workdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
 FROM parity/parity:v1.11.1
-ENV HOME /home
-WORKDIR $HOME
 
 RUN ln -s /parity/parity /usr/bin
 


### PR DESCRIPTION
If the WORKDIR is set to `/home`, the data volume is not storing anything.
Let's keep it in the default `/root` as the other testnet containers.